### PR TITLE
Make all fields of the credentials file optional

### DIFF
--- a/connection_testcases.json
+++ b/connection_testcases.json
@@ -2558,6 +2558,33 @@
     }
   },
   {
+    "fs": {
+      "files": {
+        "/home/edgedb/test/credentials.json": "{}"
+      }
+    },
+    "name": "credentials_file_test_empty_credentials_file",
+    "opts": {
+      "credentialsFile": "/home/edgedb/test/credentials.json"
+    },
+    "result": {
+      "address": [
+        "localhost",
+        5656
+      ],
+      "branch": "__default__",
+      "database": "edgedb",
+      "password": null,
+      "secretKey": null,
+      "serverSettings": {},
+      "tlsCAData": null,
+      "tlsSecurity": "strict",
+      "tlsServerName": null,
+      "user": "edgedb",
+      "waitUntilAvailable": "PT30S"
+    }
+  },
+  {
     "env": {
       "EDGEDB_PORT": "1234"
     },
@@ -3621,20 +3648,6 @@
     "name": "error_file_not_found_test_3",
     "opts": {
       "dsn": "edgedb://testuser@localhost/db?secret_key_file=/home/edgedb/secret_key"
-    }
-  },
-  {
-    "error": {
-      "type": "invalid_credentials_file"
-    },
-    "fs": {
-      "files": {
-        "/home/edgedb/test/credentials.json": "{\"port\": 10702, \"password\": \"lZTBy1RVCfOpBAOwSCwIyBIR\", \"database\": \"test3n\"}"
-      }
-    },
-    "name": "error_invalid_credentials_file_test_0",
-    "opts": {
-      "credentialsFile": "/home/edgedb/test/credentials.json"
     }
   },
   {

--- a/tests/credentials/file.jsonc
+++ b/tests/credentials/file.jsonc
@@ -2,6 +2,18 @@
   {
     "fs": {
       "files": {
+        "/home/edgedb/test/credentials.json": "{}"
+      }
+    },
+    "name": "test_empty_credentials_file",
+    "opts": {
+      "credentialsFile": "/home/edgedb/test/credentials.json"
+    },
+    "result": {}
+  },
+  {
+    "fs": {
+      "files": {
         "/home/edgedb/test/credentials.json": "{\"port\": 10702, \"user\": \"test3n\"}"
       }
     },

--- a/tests/error/invalid_credentials_file.jsonc
+++ b/tests/error/invalid_credentials_file.jsonc
@@ -5,20 +5,6 @@
     },
     "fs": {
       "files": {
-        "/home/edgedb/test/credentials.json": "{\"port\": 10702, \"password\": \"lZTBy1RVCfOpBAOwSCwIyBIR\", \"database\": \"test3n\"}"
-      }
-    },
-    "name": "test_0",
-    "opts": {
-      "credentialsFile": "/home/edgedb/test/credentials.json"
-    }
-  },
-  {
-    "error": {
-      "type": "invalid_credentials_file"
-    },
-    "fs": {
-      "files": {
         "/home/edgedb/test/credentials.json": "{\"port\": 10702, \"user\": 123, \"password\": \"lZTBy1RVCfOpBAOwSCwIyBIR\", \"database\": \"test3n\"}"
       }
     },


### PR DESCRIPTION
Specifying a credentials file, even if empty, should be sufficient to ensure a successful connection.

In the case where host or port are missing, the credentials file will contribute the default `localhost:5656`.

It is no longer an error to specify a credentials file with a missing user.

